### PR TITLE
Add prettier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: egordm/gha-yarn-node-cache@v1
+
+      - name: Install node modules
+        run: yarn install
+
+      - name: Report problems
+        run: yarn problems
+
+      - name: Run tests
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/node-rsa": "^1.0.0",
     "jest": "^26.6.3",
     "node-rsa": "^1.1.1",
+    "prettier": "^2.3.2",
     "rollup": "^2.6.1",
     "ts-jest": "^26.5.6",
     "typescript": "^3.8.3"
@@ -24,9 +25,11 @@
     "jwks-rsa": "^1.12.1"
   },
   "scripts": {
-    "problems": "yarn tsc --noEmit",
-    "test": "jest",
     "build": "yarn tsc && rollup -c && cp lib/*.d.ts dist",
-    "release": "yarn problems && yarn test && yarn build && git push && yarn publish --access public && git push --tags"
+    "format": "prettier -w src/*.ts",
+    "lint:format": "prettier -c src/*.ts",
+    "problems": "yarn tsc --noEmit && yarn lint:format",
+    "release": "yarn problems && yarn test && yarn build && git push && yarn publish --access public && git push --tags",
+    "test": "jest"
   }
 }

--- a/src/TokenVerifier.test.ts
+++ b/src/TokenVerifier.test.ts
@@ -16,7 +16,7 @@ describe("TokenVerifier", () => {
   });
 
   test("with invalid JWT", async () => {
-    await expect(verifier((null as unknown) as string)).rejects.toEqual(
+    await expect(verifier(null as unknown as string)).rejects.toEqual(
       new JsonWebTokenError("jwt must be provided")
     );
     await expect(verifier("")).rejects.toEqual(

--- a/src/TokenVerifier.ts
+++ b/src/TokenVerifier.ts
@@ -19,22 +19,24 @@ export interface VerifyToken {
   (token: string): Promise<Payload>;
 }
 
-const TokenVerifier = (config: Config): VerifyToken => async (token: string) =>
-  await new Promise((resolve, reject) => {
-    verify(
-      token,
-      (header, callback) => {
-        config
-          .getKey(header)
-          .then((k) => callback(null, k))
-          .catch((err) => callback(err));
-      },
-      {
-        issuer: config.issuer,
-        audience: config.audiences,
-      },
-      (err, payload) => (err ? reject(err) : resolve(payload as Payload))
-    );
-  });
+const TokenVerifier =
+  (config: Config): VerifyToken =>
+  async (token: string) =>
+    await new Promise((resolve, reject) => {
+      verify(
+        token,
+        (header, callback) => {
+          config
+            .getKey(header)
+            .then((k) => callback(null, k))
+            .catch((err) => callback(err));
+        },
+        {
+          issuer: config.issuer,
+          audience: config.audiences,
+        },
+        (err, payload) => (err ? reject(err) : resolve(payload as Payload))
+      );
+    });
 
 export default TokenVerifier;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3087,6 +3087,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"


### PR DESCRIPTION
This patch adds prettier and a corresponding lint check that's run in the CI workflow.

See https://github.com/keratin/authn-js/pull/43 for prior art in `authn-js`.